### PR TITLE
Fetching data from DatoCMS with GraphQL

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -3,7 +3,7 @@ import websitePageHOC from '../src/components/wrappers/WebsitePage/hoc';
 import AboutScreen from '../src/components/screens/AboutScreen';
 
 export async function getStaticProps() {
-  const TOKEN = '8acfdc27f6570ea84dca24076dec2a';
+  const TOKEN = process.env.DATO_CMS_TOKEN;
 
   const DatoCMSURL = 'https://graphql.datocms.com/';
 

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,28 +1,8 @@
-import { GraphQLClient, gql } from 'graphql-request';
 import websitePageHOC from '../src/components/wrappers/WebsitePage/hoc';
-import AboutScreen from '../src/components/screens/AboutScreen';
+import AboutScreen, { getContent } from '../src/components/screens/AboutScreen';
 
 export async function getStaticProps() {
-  const TOKEN = process.env.DATO_CMS_TOKEN;
-
-  const DatoCMSURL = 'https://graphql.datocms.com/';
-
-  const client = new GraphQLClient(DatoCMSURL, {
-    headers: {
-      Authorization: `Bearer ${TOKEN}`,
-    },
-  });
-
-  const query = gql`
-    query {
-      pageSobre {
-        pageTitle
-        pageDescription
-      }
-    }
-  `;
-
-  const messages = await client.request(query);
+  const messages = await getContent();
 
   return {
     props: {

--- a/src/components/screens/AboutScreen/getContent.js
+++ b/src/components/screens/AboutScreen/getContent.js
@@ -1,0 +1,18 @@
+import { CMSGraphQLClient, gql } from '../../../infra/cms/CMSGraphQLClient';
+
+// eslint-disable-next-line import/prefer-default-export
+export async function getContent() {
+  const query = gql`
+    query {
+      pageSobre {
+        pageTitle
+        pageDescription
+      }
+    }
+  `;
+  const client = CMSGraphQLClient();
+
+  const response = await client.query({ query });
+
+  return response.data.messages;
+}

--- a/src/components/screens/AboutScreen/index.js
+++ b/src/components/screens/AboutScreen/index.js
@@ -4,6 +4,8 @@ import Box from '../../foundation/layout/Box';
 import Grid from '../../foundation/layout/Grid';
 import Text from '../../foundation/Text';
 
+export { getContent } from './getContent';
+
 export default function AboutScreen({ messages }) {
   // console.log(messages);
   return (

--- a/src/infra/cms/CMSGraphQLClient.js
+++ b/src/infra/cms/CMSGraphQLClient.js
@@ -1,0 +1,26 @@
+import { GraphQLClient, gql as GraphQLTag } from 'graphql-request';
+
+export const gql = GraphQLTag;
+
+export function CMSGraphQLClient() {
+  const TOKEN = process.env.DATO_CMS_TOKEN;
+  const DatoCMSURL = 'https://graphql.datocms.com/';
+
+  const client = new GraphQLClient(DatoCMSURL, {
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+    },
+  });
+
+  return {
+    async query({ query, variables }) {
+      const messages = await client.request(query, variables);
+
+      return {
+        data: {
+          messages,
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
- Add DatoCMS token to .env.local file
- Refactor 'About' page API functions into 'getContent()' and client