### PR TITLE
Refactoring CMS 'messages' data and preview mode

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -1,8 +1,8 @@
 import websitePageHOC from '../src/components/wrappers/WebsitePage/hoc';
 import AboutScreen, { getContent } from '../src/components/screens/AboutScreen';
 
-export async function getStaticProps() {
-  const messages = await getContent();
+export async function getStaticProps({ preview }) {
+  const messages = await getContent({ preview });
 
   return {
     props: {

--- a/pages/api/exit-preview.js
+++ b/pages/api/exit-preview.js
@@ -1,0 +1,8 @@
+// para sair do preview -> /api/exit-preview
+export default function handler(req, res) {
+  res.clearPreviewData();
+
+  res.writeHead(307, { location: '/' });
+
+  return res.end();
+}

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -1,0 +1,14 @@
+// para acessar o preview -> /api/preview
+export default function handler(req, res) {
+  res.setPreviewData({});
+
+  // so é possivel acessar o preview passando /api/preview?key=BIRDMAN
+  const key = 'BIRDMAN';
+  if (req.query.key !== key) {
+    return res.status(401).json({ message: 'Invalid Key to enable preview' });
+  }
+
+  res.writeHead(307, { location: '/' });
+
+  return res.end();
+}

--- a/src/components/foundation/Text/index.js
+++ b/src/components/foundation/Text/index.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import get from 'lodash/get';
 import propToStyle from '../../../theme/utils/propToStyle';
 import breakpointsMedia from '../../../theme/utils/breakpointsMedia';
 import Link from '../../commons/Link';
+import { WebsitePageContext } from '../../wrappers/WebsitePage/context';
 
 export const TextStyleVariantsMap = {
   paragraph1: css`
@@ -47,7 +48,20 @@ const TextBase = styled.span`
   ${propToStyle('textAlign')}
 `;
 
-export default function Text({ tag, variant, children, href, ...props }) {
+export default function Text({
+  tag,
+  variant,
+  children,
+  href,
+  cmsKey,
+  ...props
+}) {
+  const websitePageContext = useContext(WebsitePageContext);
+
+  const componentContent = cmsKey
+    ? websitePageContext.getCMSContent(cmsKey)
+    : children;
+
   if (href) {
     return (
       <TextBase
@@ -57,7 +71,7 @@ export default function Text({ tag, variant, children, href, ...props }) {
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...props}
       >
-        {children}
+        {componentContent}
       </TextBase>
     );
   }
@@ -68,7 +82,7 @@ export default function Text({ tag, variant, children, href, ...props }) {
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     >
-      {children}
+      {componentContent}
     </TextBase>
   );
 }
@@ -78,6 +92,7 @@ Text.propTypes = {
   href: PropTypes.string,
   variant: PropTypes.string,
   children: PropTypes.node,
+  cmsKey: PropTypes.string,
 };
 
 Text.defaultProps = {
@@ -85,4 +100,5 @@ Text.defaultProps = {
   variant: 'paragraph1',
   children: null,
   href: '',
+  cmsKey: undefined,
 };

--- a/src/components/screens/AboutScreen/getContent.js
+++ b/src/components/screens/AboutScreen/getContent.js
@@ -1,7 +1,7 @@
 import { CMSGraphQLClient, gql } from '../../../infra/cms/CMSGraphQLClient';
 
 // eslint-disable-next-line import/prefer-default-export
-export async function getContent() {
+export async function getContent({ preview }) {
   const query = gql`
     query {
       pageSobre {
@@ -10,7 +10,7 @@ export async function getContent() {
       }
     }
   `;
-  const client = CMSGraphQLClient();
+  const client = CMSGraphQLClient({ preview });
 
   const response = await client.query({ query });
 

--- a/src/components/screens/AboutScreen/index.js
+++ b/src/components/screens/AboutScreen/index.js
@@ -17,9 +17,12 @@ export default function AboutScreen({ messages }) {
             offset={{ md: 2 }}
             flex={1}
           >
-            <Text variant="title" tag="h2" color="tertiary.main">
-              {messages.pageSobre.pageTitle}
-            </Text>
+            <Text
+              variant="title"
+              tag="h2"
+              color="tertiary.main"
+              cmsKey="pageSobre.pageTitle"
+            />
 
             <Box
               dangerouslySetInnerHTML={{

--- a/src/components/wrappers/WebsitePage/context/index.js
+++ b/src/components/wrappers/WebsitePage/context/index.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+// eslint-disable-next-line import/prefer-default-export
+export const WebsitePageContext = createContext({
+  toggleRegisterModal: () => {},
+  getCMSContent: (cmsKey) => cmsKey,
+});

--- a/src/components/wrappers/WebsitePage/hoc/index.js
+++ b/src/components/wrappers/WebsitePage/hoc/index.js
@@ -12,7 +12,11 @@ export default function websitePageHOC(
 ) {
   return (props) => (
     <WebsiteGlobalProvider>
-      <WebsitePageWrapper {...pageWrapperProps} {...props.pageWrapperProps}>
+      <WebsitePageWrapper
+        {...pageWrapperProps}
+        {...props.pageWrapperProps}
+        messages={props.messages}
+      >
         <PageComponent {...props} />
       </WebsitePageWrapper>
     </WebsiteGlobalProvider>

--- a/src/components/wrappers/WebsitePage/index.js
+++ b/src/components/wrappers/WebsitePage/index.js
@@ -1,5 +1,6 @@
-import React, { createContext, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import get from 'lodash/get';
 import Footer from '../../commons/Footer';
 import Menu from '../../commons/Menu';
 import Modal from '../../commons/Modal';
@@ -7,15 +8,16 @@ import Box from '../../foundation/layout/Box';
 import RegisterForm from '../../patterns/RegisterForm';
 import SEO from '../../commons/SEO';
 
-export const WebsitePageContext = createContext({
-  toggleRegisterModal: () => {},
-});
+import { WebsitePageContext } from './context';
+
+export { WebsitePageContext } from './context';
 
 export default function WebsitePageWrapper({
   children,
   seoProps,
   pageBoxProps,
   menuProps,
+  messages,
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -24,6 +26,9 @@ export default function WebsitePageWrapper({
       value={{
         toggleRegisterModal: () => {
           setIsModalOpen(!isModalOpen);
+        },
+        getCMSContent: (cmsKey) => {
+          return get(messages, cmsKey);
         },
       }}
     >
@@ -62,6 +67,7 @@ WebsitePageWrapper.defaultProps = {
   menuProps: {
     display: true,
   },
+  messages: {},
 };
 
 WebsitePageWrapper.propTypes = {
@@ -77,4 +83,6 @@ WebsitePageWrapper.propTypes = {
     backgroundPosition: PropTypes.string,
   }),
   children: PropTypes.node.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  messages: PropTypes.object,
 };

--- a/src/infra/cms/CMSGraphQLClient.js
+++ b/src/infra/cms/CMSGraphQLClient.js
@@ -2,9 +2,11 @@ import { GraphQLClient, gql as GraphQLTag } from 'graphql-request';
 
 export const gql = GraphQLTag;
 
-export function CMSGraphQLClient() {
+export function CMSGraphQLClient({ preview } = { preview: false }) {
+  const DatoCMSURL = preview
+    ? 'https://graphql.datocms.com/preview'
+    : 'https://graphql.datocms.com';
   const TOKEN = process.env.DATO_CMS_TOKEN;
-  const DatoCMSURL = 'https://graphql.datocms.com/';
 
   const client = new GraphQLClient(DatoCMSURL, {
     headers: {


### PR DESCRIPTION
- Add preview mode for 'About' page
- pass 'messages' props via 'websitePageContext' to avoid prop drill